### PR TITLE
Update sensor.py - new DEVICE_CLASS for VOC in pbb

### DIFF
--- a/esphome/components/ens160/sensor.py
+++ b/esphome/components/ens160/sensor.py
@@ -6,7 +6,7 @@ from esphome.const import (
     ICON_CHEMICAL_WEAPON,
     ICON_RADIATOR,
     DEVICE_CLASS_CARBON_DIOXIDE,
-    DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS,
+    DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS_PARTS,
     STATE_CLASS_MEASUREMENT,
     UNIT_PARTS_PER_MILLION,
     UNIT_PARTS_PER_BILLION,
@@ -45,7 +45,7 @@ CONFIG_SCHEMA = (
                 unit_of_measurement=UNIT_PARTS_PER_BILLION,
                 icon=ICON_RADIATOR,
                 accuracy_decimals=0,
-                device_class=DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS,
+                device_class=DEVICE_CLASS_VOLATILE_ORGANIC_COMPOUNDS_PARTS,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Required(CONF_AQI): sensor.sensor_schema(


### PR DESCRIPTION
# What does this implement/fix?
Hi Vincent small update to VOC device class

Recent ESPHome update introduces new device class for VOC with units ppb - sensor.py updated with new device class


